### PR TITLE
drivers: mpsl: fix TEMP_NRF5_MPSL option

### DIFF
--- a/drivers/mpsl/temp_nrf5/CMakeLists.txt
+++ b/drivers/mpsl/temp_nrf5/CMakeLists.txt
@@ -8,6 +8,6 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_TEMP_NRF5_MPSL temp_nrf5_mpsl.c)
 
-if(CONFIG_TEMP_NRF5 AND CONFIG_TEMP_NRF5_MPSL)
-  message(FATAL_ERROR "CONFIG_TEMP_NRF5 and CONFIG_TEMP_NRF5_MPSL have both been enabled, but must not be used together.")
+if(CONFIG_TEMP_NRF5_MPSL AND NOT CONFIG_TEMP_NRF5_FORCE_ALT)
+  message(FATAL_ERROR "CONFIG_TEMP_NRF5_MPSL and CONFIG_TEMP_NRF5_FORCE_ALT must both be enabled.")
 endif()

--- a/drivers/mpsl/temp_nrf5/Kconfig
+++ b/drivers/mpsl/temp_nrf5/Kconfig
@@ -7,6 +7,10 @@
 
 config TEMP_NRF5_MPSL
 	bool "nRF5 MPSL Temperature Sensor"
-	depends on HAS_HW_NRF_TEMP && MPSL
+	default y
+	depends on DT_HAS_NORDIC_NRF_TEMP_ENABLED
+	depends on HAS_HW_NRF_TEMP
+	depends on MPSL
+	select TEMP_NRF5_FORCE_ALT
 	help
 	  Enable MPSL driver for nRF5 temperature sensor.


### PR DESCRIPTION
With
https://github.com/zephyrproject-rtos/zephyr/commit/f0441fba58a242d4fcc70794f6250ace358baae4
merged upstream, `TEMP_NRF5` is enabled by default if temperature sensor
is defined in devicetree. That caused build errors, as `TEMP_NRF5_MPSL`
option required `TEMP_NRF5` to be disabled.

This commit fixes that error by treating `TEMP_NRF5_MPSL` as an
alternative implementation of temperature driver, selected through
`TEMP_NRF5_FORCE_ALT`. The intended usage of that symbol is to allow the
application to select `TEMP_NRF5`, but to use a different underlying
source code for actually driving the sensor. `TEMP_NRF5_MPSL` is aligned
to achieve that.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>