### PR TITLE
applications/machine_learning: Set UART forwarder via DTS overlay

### DIFF
--- a/applications/machine_learning/configuration/nrf52840dk_nrf52840/app.overlay
+++ b/applications/machine_learning/configuration/nrf52840dk_nrf52840/app.overlay
@@ -1,4 +1,8 @@
 / {
+	chosen {
+		nordic,ml_app_ei_data_forwarder_uart = &uart0;
+	};
+
 	sensor_sim: sensor-sim {
 		compatible = "nordic,sensor-sim";
 		label = "SENSOR_SIM";

--- a/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/app.overlay
+++ b/applications/machine_learning/configuration/nrf5340dk_nrf5340_cpuapp/app.overlay
@@ -1,6 +1,7 @@
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
+		nordic,ml_app_ei_data_forwarder_uart = &uart0;
 	};
 };
 

--- a/applications/machine_learning/configuration/thingy52_nrf52832/app.overlay
+++ b/applications/machine_learning/configuration/thingy52_nrf52832/app.overlay
@@ -1,4 +1,8 @@
 / {
+	chosen {
+		nordic,ml_app_ei_data_forwarder_uart = &uart0;
+	};
+
 	leds {
 		status = "okay";
 		label = "ML state LED";

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/app.overlay
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp/app.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
+		nordic,ml_app_ei_data_forwarder_uart = &uart0;
 	};
 };
 

--- a/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/app.overlay
+++ b/applications/machine_learning/configuration/thingy53_nrf5340_cpuapp_ns/app.overlay
@@ -7,6 +7,7 @@
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
+		nordic,ml_app_ei_data_forwarder_uart = &uart0;
 	};
 };
 

--- a/applications/machine_learning/src/modules/Kconfig.ei_data_forwarder
+++ b/applications/machine_learning/src/modules/Kconfig.ei_data_forwarder
@@ -65,13 +65,6 @@ config ML_APP_EI_DATA_FORWARDER_BUF_COUNT
 	  application module. This Kconfig option specifies number of sensor samples temporarily
 	  stored by the application module.
 
-config ML_APP_EI_DATA_FORWARDER_UART_DEV
-	string "UART device name"
-	depends on ML_APP_EI_DATA_FORWARDER_UART
-	default "UART_0"
-	help
-	  Name of UART device that is used to forward data.
-
 module = ML_APP_EI_DATA_FORWARDER
 module-str = EI data forwarder
 source "subsys/logging/Kconfig.template.log_config"

--- a/applications/machine_learning/src/modules/ei_data_forwarder_uart.c
+++ b/applications/machine_learning/src/modules/ei_data_forwarder_uart.c
@@ -19,7 +19,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_ML_APP_EI_DATA_FORWARDER_LOG_LEVEL);
 
-#define UART_LABEL		CONFIG_ML_APP_EI_DATA_FORWARDER_UART_DEV
+#define EI_DATA_FORWARDER_UART_NODE DT_CHOSEN(nordic_ml_app_ei_data_forwarder_uart)
+#define EI_DATA_FORWARDER_UART_DEV DEVICE_DT_GET(EI_DATA_FORWARDER_UART_NODE)
+
 #define UART_BUF_SIZE		CONFIG_ML_APP_EI_DATA_FORWARDER_BUF_SIZE
 #define ML_APP_MODE_CONTROL	IS_ENABLED(CONFIG_ML_APP_MODE_EVENTS)
 
@@ -156,9 +158,9 @@ static void uart_cb(const struct device *dev, struct uart_event *evt, void *user
 
 static int init(void)
 {
-	dev = device_get_binding(UART_LABEL);
+	dev = EI_DATA_FORWARDER_UART_DEV;
 
-	if (!dev) {
+	if (!device_is_ready(dev)) {
 		LOG_ERR("UART device binding failed");
 		return -ENXIO;
 	}


### PR DESCRIPTION
With removal of label properties, from DTS tree, it is no longer
possible to identify UART by string label. This also means that
it is no longer possible to use device_get_binding to obtain
pointer to UART device, and DEVICE_DT_GET needs to be used instead.
Unfortunately this makes Kconfig option
CONFIG_ML_APP_EI_DATA_FORWARDER_UART_DEV obsolete and DTS overaly
is now needed to attach ml_app_ei_data_forwarder_uart DTS node
label to UART that will be used for data forwarder.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>