### PR TITLE
samples: lwm2m_client: Fix missing event handler

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -341,6 +341,10 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 		LOG_DBG("Queue mode RX window closed");
 		break;
 
+	case LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED:
+		LOG_DBG("LwM2M engine suspended");
+		break;
+
 	case LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR:
 		LOG_ERR("LwM2M engine reported a network error.");
 		reconnect = true;


### PR DESCRIPTION
Added vent handler for LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>