### PR TITLE
mpsl: fem: remove deprecated DT_GPIO_LABEL from simple_gpio

### DIFF
--- a/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
+++ b/subsys/mpsl/fem/nrf21540_gpio/mpsl_fem_nrf21540_gpio.c
@@ -291,7 +291,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t tx_en_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), tx_en_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&tx_en_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), rx_en_gpios), _FULL_NAME));
+		&tx_en_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), tx_en_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(tx_en_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
@@ -307,7 +307,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t pdn_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), pdn_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&pdn_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), rx_en_gpios), _FULL_NAME));
+		&pdn_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), pdn_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(pdn_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
@@ -315,7 +315,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t mode_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), mode_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&mode_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), rx_en_gpios), _FULL_NAME));
+		&mode_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), mode_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(mode_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
@@ -323,7 +323,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t ant_sel_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&ant_sel_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), rx_en_gpios), _FULL_NAME));
+		&ant_sel_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), ant_sel_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(ant_sel_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 

--- a/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
+++ b/subsys/mpsl/fem/simple_gpio/mpsl_fem_simple_gpio.c
@@ -204,7 +204,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t ctx_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), ctx_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&ctx_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), ctx_gpios));
+		&ctx_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), ctx_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(ctx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 
@@ -212,7 +212,7 @@ static int mpsl_fem_host_init(const struct device *dev)
 	uint8_t crx_pin = DT_GPIO_PIN(DT_NODELABEL(nrf_radio_fem), crx_gpios);
 
 	mpsl_fem_pin_extend_with_port(
-		&crx_pin, DT_GPIO_LABEL(DT_NODELABEL(nrf_radio_fem), crx_gpios));
+		&crx_pin, UTIL_CAT(DT_GPIO_CTLR(DT_NODELABEL(nrf_radio_fem), crx_gpios), _FULL_NAME));
 	soc_secure_gpio_pin_mcu_select(crx_pin, NRF_GPIO_PIN_MCUSEL_NETWORK);
 #endif
 


### PR DESCRIPTION
This commit removes the usage of deprecated DT_GPIO_LABEL macro from
mpsl_fem_simple_gpio implementation.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>