### PR TITLE
cmake: add ExternalNcsVariantProject_Add() function

### DIFF
--- a/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
+++ b/cmake/sysbuild/modules/ncs_sysbuild_extensions.cmake
@@ -1,0 +1,55 @@
+#
+# Copyright (c) 2023 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+
+include_guard(GLOBAL)
+
+# Usage:
+#   ExternalNcsVariantProject_Add(APPLICATION <name>
+#                                 VARIANT <name>
+#   )
+#
+# This function includes a variant build of an existing Zephyr based build
+# system into the multiimage build system
+#
+# APPLICATION <name>: Name of the application which is used as the source for
+#                     the variant build.
+# VARIANT <name>:     Name of the variant build.
+function(ExternalNcsVariantProject_Add)
+  cmake_parse_arguments(VBUILD "" "APPLICATION;VARIANT" "" ${ARGN})
+
+  ExternalProject_Get_Property(${VBUILD_APPLICATION} SOURCE_DIR BINARY_DIR)
+  set(${VBUILD_APPLICATION}_BINARY_DIR ${BINARY_DIR})
+
+  ExternalZephyrProject_Add(
+    APPLICATION ${VBUILD_VARIANT}
+    SOURCE_DIR ${SOURCE_DIR}
+    BUILD_ONLY true
+  )
+
+  get_cmake_property(sysbuild_cache CACHE_VARIABLES)
+  foreach(var_name ${sysbuild_cache})
+    if("${var_name}" MATCHES "^(${}_.*)$")
+      string(LENGTH "${VBUILD_APPLICATION}" tmplen)
+      string(SUBSTRING "${var_name}" ${tmplen} -1 tmp)
+      set(${VBUILD_VARIANT}${tmp} "${${var_name}}" CACHE UNINITIALIZED "" FORCE)
+    endif()
+  endforeach()
+
+  ExternalProject_Get_Property(${VBUILD_VARIANT} BINARY_DIR)
+  ExternalProject_Add_Step(${VBUILD_VARIANT} variant_config
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${${VBUILD_APPLICATION}_BINARY_DIR}/zephyr/.config
+            ${BINARY_DIR}/zephyr/.config
+    DEPENDERS build
+    ALWAYS True
+  )
+
+  # Disable menuconfig and friends in variant builds by substitutuin with a
+  # dummy target that does nothing except returning succesfully.
+  set_property(TARGET ${VBUILD_VARIANT} APPEND PROPERTY _EP_CMAKE_ARGS
+    -DKCONFIG_TARGETS=variant_config
+    "-DEXTRA_KCONFIG_TARGET_COMMAND_FOR_variant_config=-c\;''"
+  )
+endfunction()

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -52,6 +52,8 @@ endfunction(${SYSBUILD_CURRENT_MODULE_NAME}_post_cmake)
 # Consider if this shoulc come through Sysbuild Kconfig flag.
 set(NCS_SYSBUILD_PARTITION_MANAGER TRUE PARENT_SCOPE)
 
+list(APPEND CMAKE_MODULE_PATH ${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/modules)
+include(ncs_sysbuild_extensions)
 include(${CMAKE_CURRENT_LIST_DIR}/extensions.cmake)
 
 if(SB_CONFIG_SECURE_BOOT)

--- a/sysbuild/secureboot.cmake
+++ b/sysbuild/secureboot.cmake
@@ -41,36 +41,10 @@ if(SB_CONFIG_SECURE_BOOT)
     set(image s1_image)
 
     if(SB_CONFIG_BOOTLOADER_MCUBOOT)
-      set(s1_source_image mcuboot)
-      set(s1_source_dir ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/)
-
-      # Set corresponding values in s1 variant of mcuboot
-      set(${image}_CONFIG_BOOT_SIGNATURE_TYPE_${SB_CONFIG_SIGNATURE_TYPE} y CACHE STRING
-          "MCUBOOT signature type" FORCE
-      )
-      set(${image}_CONFIG_BOOT_SIGNATURE_KEY_FILE
-          \"${SB_CONFIG_BOOT_SIGNATURE_KEY_FILE}\" CACHE STRING
-          "Signature key file for signing" FORCE
-      )
+      ExternalNcsVariantProject_Add(APPLICATION mcuboot VARIANT ${image})
     else()
-      set(s1_source_image ${DEFAULT_IMAGE})
-      set(s1_source_dir ${APP_DIR})
+      ExternalNcsVariantProject_Add(APPLICATION ${DEFAULT_IMAGE} VARIANT ${image})
     endif()
-
-    get_cmake_property(sysbuild_cache CACHE_VARIABLES)
-    foreach(var_name ${sysbuild_cache})
-      if("${var_name}" MATCHES "^(${s1_source_image}_.*)$")
-        string(LENGTH "${s1_source_image}" tmplen)
-        string(SUBSTRING "${var_name}" ${tmplen} -1 tmp)
-        set(${image}${tmp} "${${var_name}}" CACHE UNINITIALIZED "" FORCE)
-      endif()
-    endforeach()
-
-    ExternalZephyrProject_Add(
-      APPLICATION ${image}
-      SOURCE_DIR ${s1_source_dir}
-      BUILD_ONLY true
-    )
 
     set_property(GLOBAL APPEND PROPERTY
         PM_${SB_CONFIG_SECURE_BOOT_DOMAIN}_IMAGES


### PR DESCRIPTION
The ExternalNcsVariantProject_Add() function will read properties from an existing Zephyr image build and re-create the same settings in a variant build.