### PR TITLE
sysbuild: zigbee: Enable 802.15.4

### DIFF
--- a/tests/subsys/zigbee/osif/nvram/Kconfig.sysbuild
+++ b/tests/subsys/zigbee/osif/nvram/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config NRF_DEFAULT_802154
+	default y

--- a/tests/subsys/zigbee/zboss_api/alarm_api/Kconfig.sysbuild
+++ b/tests/subsys/zigbee/zboss_api/alarm_api/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config NRF_DEFAULT_802154
+	default y


### PR DESCRIPTION
Each test that enables the main ZIGBEE Kconfig requires to program the network core with 802.15.4 image.