### PR TITLE
samples: lwm2m_client: Fixed building with sysbuild

### DIFF
--- a/samples/cellular/lwm2m_client/sysbuild.conf
+++ b/samples/cellular/lwm2m_client/sysbuild.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+SB_CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
The sample did not build because the MCUBOOT bootloader was not configured in sysbuild.