### PR TITLE
cmake: sysbuild: Make b0_packaging.cmake backwards compatible

### DIFF
--- a/cmake/sysbuild/b0_packaging.cmake
+++ b/cmake/sysbuild/b0_packaging.cmake
@@ -6,13 +6,18 @@ include(${ZEPHYR_NRF_MODULE_DIR}/cmake/fw_zip.cmake)
 
 sysbuild_get(app_fw_info_firmware_version IMAGE ${DEFAULT_IMAGE} VAR CONFIG_FW_INFO_FIRMWARE_VERSION KCONFIG)
 
+set(s0_name signed_by_b0_s0_image.bin)
+set(s1_name signed_by_b0_s1_image.bin)
+
 generate_dfu_zip(
   OUTPUT ${PROJECT_BINARY_DIR}/dfu_application.zip
   BIN_FILES ${PROJECT_BINARY_DIR}/signed_by_b0_${DEFAULT_IMAGE}.bin ${PROJECT_BINARY_DIR}/signed_by_b0_s1_image.bin
+  ZIP_NAMES ${s0_name} ${s1_name}
   TYPE application
+  IMAGE ${DEFAULT_IMAGE}
   SCRIPT_PARAMS
-  "signed_by_b0_${DEFAULT_IMAGE}.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
-  "signed_by_b0_s1_image.binload_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
+  "${s0_name}load_address=$<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>"
+  "${s1_image}load_address=$<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>"
   "version_B0=${app_fw_info_firmware_version}"
   DEPENDS
   ${DEFAULT_IMAGE}_extra_byproducts


### PR DESCRIPTION
Changes bring back backwards compatibility to ensure compatibility with existing tools and applications.

Jira: NCSDK-27566